### PR TITLE
Test CI and build on PR and schedule - Fix pnpm install in container

### DIFF
--- a/.github/workflows/release-container.yaml
+++ b/.github/workflows/release-container.yaml
@@ -30,8 +30,6 @@ jobs:
         with:
           image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: latest ${{ github.ref_name }} ${{ github.sha }}
-          build-args: |
-            JWT_SECRET=${{ secrets.JWT_SECRET }}
           containerfiles: |
             ./Dockerfile
           oci: true

--- a/.github/workflows/release-container.yaml
+++ b/.github/workflows/release-container.yaml
@@ -1,0 +1,52 @@
+name: Release Horus Container
+
+on:
+  release:
+    types: [released]
+
+env:
+  ACTIONS_RUNNER_DEBUG: false
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-release-container:
+    if: github.ref_type == 'tag'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+      deployments: write
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Buildah Action
+        uses: redhat-actions/buildah-build@v2
+        id: build-image
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: latest ${{ github.ref_name }} ${{ github.sha }}
+          build-args: |
+            JWT_SECRET=${{ secrets.JWT_SECRET }}
+          containerfiles: |
+            ./Dockerfile
+          oci: true
+
+      - name: Login to GitHub Container Registry
+        uses: redhat-actions/podman-login@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push To ghcr.io
+        id: push-to-ghcr
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build-image.outputs.image }}
+          tags: ${{ steps.build-image.outputs.tags }}
+          registry: ${{ env.REGISTRY }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,18 +1,20 @@
-name: Release Horus Container
+name: CI & Build checks
 
 on:
-  release:
-    types: [released]
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+  schedule:
+    - cron: "0 4 * * 4"
 
 env:
   ACTIONS_RUNNER_DEBUG: false
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  JWT_SECRET: ${{ secrets.JWT_SECRET }}
 
 jobs:
   build-release-container:
-    if: github.ref_type == 'tag'
     runs-on: ubuntu-latest
     permissions:
       actions: write
@@ -32,22 +34,10 @@ jobs:
           image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: latest ${{ github.ref_name }} ${{ github.sha }}
           build-args: |
-            JWT_SECRET=${{ env.JWT_SECRET }}
+            JWT_SECRET=${{ secrets.JWT_SECRET }}
           containerfiles: |
             ./Dockerfile
           oci: true
 
-      - name: Login to GitHub Container Registry
-        uses: redhat-actions/podman-login@v1
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Push To ghcr.io
-        id: push-to-ghcr
-        uses: redhat-actions/push-to-registry@v2
-        with:
-          image: ${{ steps.build-image.outputs.image }}
-          tags: ${{ steps.build-image.outputs.tags }}
-          registry: ${{ env.REGISTRY }}
+      - name: Print image urls
+        run: echo "Images built ${{ toJSON(steps.build-image.outputs) }}"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,8 +33,6 @@ jobs:
         with:
           image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: testing ${{ github.sha }}
-          build-args: |
-            JWT_SECRET=${{ secrets.JWT_SECRET }}
           containerfiles: |
             ./Dockerfile
           oci: true

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,7 +14,7 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build-release-container:
+  test-build-container:
     runs-on: ubuntu-latest
     permissions:
       actions: write
@@ -32,7 +32,7 @@ jobs:
         id: build-image
         with:
           image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: latest ${{ github.ref_name }} ${{ github.sha }}
+          tags: testing ${{ github.sha }}
           build-args: |
             JWT_SECRET=${{ secrets.JWT_SECRET }}
           containerfiles: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
-FROM node:22 AS frontend-build
-ENV PNPM_HOME="/pnpm"
-ENV PATH="$PNPM_HOME:$PATH"
-RUN corepack enable
+FROM node:22-alpine AS frontend-build
+
+RUN apk add --no-cache curl ca-certificates nodejs npm \
+    && npm install -g pnpm \
+    && pnpm --version
+
 WORKDIR /app/frontend
 COPY ./package.json ./pnpm-lock.yaml ./
 COPY ./tsconfig.json ./tsconfig.app.json ./tsconfig.node.json ./
@@ -9,18 +11,22 @@ COPY ./vite.config.ts ./
 COPY ./src ./src
 COPY ./public ./public
 COPY index.html .env.production ./
+
 RUN pnpm install
 RUN pnpm build
 
-FROM node:22 AS backend-build
-ENV PNPM_HOME="/pnpm"
-ENV PATH="$PNPM_HOME:$PATH"
-RUN corepack enable
+FROM node:22-alpine AS backend-build
+
+RUN apk add --no-cache curl ca-certificates nodejs npm \
+    && npm install -g pnpm \
+    && pnpm --version
+
 WORKDIR /app/backend
 COPY ./server/package.json ./server/pnpm-lock.yaml ./
 COPY ./server/tsconfig.json ./
 COPY ./server/src ./src
 COPY ./server/.env ./
+
 RUN pnpm install
 RUN pnpm build
 EXPOSE 5000 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,17 @@
 # Horus Holdings
 
+[![CI & Build checks](https://github.com/jordojordo/horus-holdings/actions/workflows/tests.yaml/badge.svg)](https://github.com/jordojordo/horus-holdings/actions/workflows/tests.yaml)
+
+[![Publish to GHCR](https://github.com/jordojordo/horus-holdings/actions/workflows/release-container.yaml/badge.svg)](https://github.com/jordojordo/horus-holdings/actions/workflows/release-container.yaml)
+
 ## Overview
 
 Horus Holdings is a cash flow management tool designed to help users track their incomes and expenses, providing a clear visualization of their cash flow over time.
 
 Named after the Egyptian god Horus, who symbolizes protection, stability, and prosperity, this application aims to bring financial clarity and control to its users. By offering robust user authentication, Horus Holdings ensures that each user's financial data remains secure and private, echoing the protective nature of its namesake.
+
+> [!TIP]
+> See it in action: https://horus.yokanga.xyz
 
 ![Frontend Demo](assets/frontend-demo.png)
 


### PR DESCRIPTION
This pull request includes several changes to the GitHub Actions workflows, Dockerfile, and README file. The most important changes involve renaming and updating the release container workflow, adding a new CI & Build checks workflow, modifying the Dockerfile to use an Alpine base image, and updating the README with new badges.

### Workflow and CI/CD changes:

* [`.github/workflows/release-container.yaml`](diffhunk://#diff-5d3a537da0e10fafaf8c1bb26c72dbda423655c272cbc65dfed2a083fffcc819L11): Renamed from `.github/workflows/release-container.yml` and removed the `JWT_SECRET` environment variable and build argument. [[1]](diffhunk://#diff-5d3a537da0e10fafaf8c1bb26c72dbda423655c272cbc65dfed2a083fffcc819L11) [[2]](diffhunk://#diff-5d3a537da0e10fafaf8c1bb26c72dbda423655c272cbc65dfed2a083fffcc819L34-L35)
* [`.github/workflows/tests.yaml`](diffhunk://#diff-95557d53bf91069e59d82b9d8fcfaf52ec84a762858983edd5ef3c9b3e4c8191R1-R41): Added a new workflow for CI & Build checks, including triggers for pull requests, scheduled runs, and manual dispatch.

### Dockerfile changes:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-R29): Switched the base image to `node:22-alpine` for both frontend and backend builds, and replaced `corepack enable` with installing `pnpm` using `apk`.

### Documentation changes:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R3-R15): Added badges for the new CI & Build checks workflow and the release container workflow, along with a tip for accessing the application.