### PR TITLE
fix: add server side pagination and fix issue with date processing

### DIFF
--- a/server/src/controllers/RecurrenceController.ts
+++ b/server/src/controllers/RecurrenceController.ts
@@ -1,20 +1,19 @@
-import type { RecurrencePayload, ExpandWindow } from '@server/types/Recurrence';
+import type { RecurrencePayload } from '@server/types/Recurrence';
 
 import { Request, Response } from 'express';
 
 import { BaseController } from '@server/controllers/BaseController';
 import { expandOccurrences } from '@server/utils/recurrence';
+import { toYMD } from '@server/utils/civilDate';
 
 class RecurrenceController extends BaseController {
   async preview(req: Request, res: Response) {
     try {
       const payload = req.body?.payload as RecurrencePayload;
-      const window  = (req.body?.window || {}) as Partial<ExpandWindow>;
       // const tz = payload.timezone || 'America/New_York';
 
-      const today = new Date().toISOString().slice(0,10);
-      const start = window.start || today;
-      const end   = window.end   || new Date(Date.now() + 1000*60*60*24*90).toISOString().slice(0,10); // +90d
+      const start = toYMD(new Date());
+      const end   = toYMD(new Date(Date.now() + 1000*60*60*24*90)); // +90d
 
       const dates = expandOccurrences(payload, { start, end });
 

--- a/server/src/utils/civilDate.ts
+++ b/server/src/utils/civilDate.ts
@@ -1,0 +1,21 @@
+export function fromYMD(ymd: string): Date {
+  const [y, m, d] = ymd.split('-').map(Number);
+
+  return new Date(Date.UTC(y, m - 1, d, 12, 0, 0)); // UTC-noon
+}
+
+export function ymd(y: number, m: number, d: number): Date {
+  return new Date(Date.UTC(y, m - 1, d, 12, 0, 0)); // UTC-noon
+}
+
+export function toYMD(date: Date): string {
+  // normalize to UTC date (noon) before slicing, so TZ never flips the day
+  const u = new Date(Date.UTC(
+    date.getUTCFullYear(),
+    date.getUTCMonth(),
+    date.getUTCDate(),
+    12, 0, 0
+  ));
+
+  return u.toISOString().slice(0, 10);
+}

--- a/server/src/utils/dateRange.ts
+++ b/server/src/utils/dateRange.ts
@@ -1,3 +1,5 @@
+import type { WhereOptions } from '@sequelize/core';
+
 import { Op } from '@sequelize/core';
 
 /**
@@ -7,7 +9,11 @@ import { Op } from '@sequelize/core';
  * - One-off items:  date BETWEEN start AND end
  * - Recurring items: anchorDate <= end AND (endDate IS NULL OR endDate >= start)
  */
-export const buildDateRangeWhere = (startISO: string, endISO: string) => {
+export const buildDateRangeWhere = (startISO?: string, endISO?: string): WhereOptions => {
+  if (!startISO || !endISO) {
+    return {};
+  }
+
   return {
     [Op.or]: [
       // One-off items (no recurrence)
@@ -19,20 +25,8 @@ export const buildDateRangeWhere = (startISO: string, endISO: string) => {
       {
         recurrenceKind: { [Op.ne]: 'none' },
         [Op.and]:       [
-          // If anchorDate is present, it must be <= end
-          {
-            [Op.or]: [
-              { anchorDate: null },
-              { anchorDate: { [Op.lte]: endISO } },
-            ],
-          },
-          // If endDate is present, it must be >= start
-          {
-            [Op.or]: [
-              { endDate: null },
-              { endDate: { [Op.gte]: startISO } },
-            ],
-          },
+          { [Op.or]: [{ anchorDate: null }, { anchorDate: { [Op.lte]: endISO } }] },
+          { [Op.or]: [{ endDate: null }, { endDate: { [Op.gte]: startISO } }] },
         ],
       },
     ],

--- a/ui/src/components/FinanceStats.vue
+++ b/ui/src/components/FinanceStats.vue
@@ -33,7 +33,7 @@ const fmtPercent = (n?: number) => {
   return `${ new Intl.NumberFormat('en-US', {
     minimumFractionDigits: 2,
     maximumFractionDigits: 2
-  }).format(n)  }%`;
+  }).format(n * 100)  }%`;
 };
 </script>
 

--- a/ui/src/components/RecurrenceBuilder/RecurrenceBuilder.vue
+++ b/ui/src/components/RecurrenceBuilder/RecurrenceBuilder.vue
@@ -194,7 +194,7 @@ async function doPreview() {
 
 <template>
   <div class="recurrence-builder flex flex-col gap-6 w-full">
-    <div class="flex flex-wrap between gap-8 mb-4">
+    <div class="date-controls flex flex-wrap between gap-8 mb-4">
       <div class="flex flex-col gap-1 w-45">
         <KLabel>Anchor date</KLabel>
         <KDateTimePicker
@@ -202,7 +202,7 @@ async function doPreview() {
           mode="date"
           :range="false"
           placeholder="Anchor date"
-          clear-button
+          :clear-button="false"
         />
       </div>
       <div class="flex flex-col gap-1 w-45">
@@ -288,5 +288,9 @@ async function doPreview() {
 </template>
 
 <style scoped>
-
+@media (max-width: 600px) {
+  .date-controls > * {
+    width: 100%;
+  }
+}
 </style>


### PR DESCRIPTION
This pull request introduces major improvements to the financial items backend and frontend, focusing on server-side filtering, sorting, and pagination for item tables, as well as more robust recurrence handling and date utilities. The changes remove client-side filtering/sorting logic from the frontend and shift these responsibilities to the backend, resulting in more efficient data loading and improved user experience. Additionally, the recurrence logic is refactored for greater consistency and reliability, especially around date and timezone handling.

### Backend: Financial Item API improvements
* Added server-side support for pagination, sorting, search, and recurrence filtering in `FinancialItemController`, including validation and query parameter handling. The response now includes paginated results and total count. (`server/src/controllers/FinancialItemController.ts`)
* Refactored date range filtering to use a reusable `buildDateRangeWhere` utility, now supporting optional start/end and tighter recurrence logic. (`server/src/utils/dateRange.ts`) [[1]](diffhunk://#diff-72366957d5546e19995928a1a57dcdb4964bfe312c97de6a2343a2357a507e8cL10-R16) [[2]](diffhunk://#diff-72366957d5546e19995928a1a57dcdb4964bfe312c97de6a2343a2357a507e8cL22-R29)

### Backend: Recurrence and Date Utilities
* Added new civil date utilities (`toYMD`, `fromYMD`, `ymd`) to ensure consistent UTC date handling, reducing timezone-related bugs. (`server/src/utils/civilDate.ts`)
* Improved recurrence expansion and next due date calculation to ensure all date manipulations use UTC for RRULE operations and only apply user timezone for weekend adjustments, fixing edge cases with included/excluded dates. (`server/src/utils/recurrence.ts`) [[1]](diffhunk://#diff-5df62bfe8913245016e2308f3ca50b71022cb3b2670f8c6f0c8a470909207cfeL19-R28) [[2]](diffhunk://#diff-5df62bfe8913245016e2308f3ca50b71022cb3b2670f8c6f0c8a470909207cfeL185-R193) [[3]](diffhunk://#diff-5df62bfe8913245016e2308f3ca50b71022cb3b2670f8c6f0c8a470909207cfeL204-R230) [[4]](diffhunk://#diff-5df62bfe8913245016e2308f3ca50b71022cb3b2670f8c6f0c8a470909207cfeL236-R251)
* Updated recurrence preview endpoint to use new civil date utilities for correct window calculation. (`server/src/controllers/RecurrenceController.ts`)

### Frontend: Table Component Refactor
* Replaced client-side filtering, sorting, and pagination in `ItemTable.vue` with a new server-driven `fetcher` for `KTableData`, supporting search, sort, recurrence filter, and pagination via API parameters. (`ui/src/components/ItemTable.vue`) [[1]](diffhunk://#diff-90b48e017a4207d3ee1c0143ee2a8cb655854755822d3b9683de6ccee4c008ccL46-L118) [[2]](diffhunk://#diff-90b48e017a4207d3ee1c0143ee2a8cb655854755822d3b9683de6ccee4c008ccL132-R96) [[3]](diffhunk://#diff-90b48e017a4207d3ee1c0143ee2a8cb655854755822d3b9683de6ccee4c008ccR166-R210) [[4]](diffhunk://#diff-90b48e017a4207d3ee1c0143ee2a8cb655854755822d3b9683de6ccee4c008ccL312-R257)
* Updated UI to disable search input while loading and to revalidate table data when recurrence filter or item kind changes. (`ui/src/components/ItemTable.vue`)

### Frontend: Miscellaneous Improvements
* Fixed percentage formatting bug in `FinanceStats.vue` to correctly display percent values. (`ui/src/components/FinanceStats.vue`)

---

**References:**  
[[1]](diffhunk://#diff-85d1570e9a045ce5497f8b9add05791b7dfeea2d14189d4c0b01fccae3d764aaL45-R104) [[2]](diffhunk://#diff-72366957d5546e19995928a1a57dcdb4964bfe312c97de6a2343a2357a507e8cL10-R16) [[3]](diffhunk://#diff-72366957d5546e19995928a1a57dcdb4964bfe312c97de6a2343a2357a507e8cL22-R29) [[4]](diffhunk://#diff-b953bc052435c359e4ef38b9324eb82bbf4ca1d85a17daeacd0f88c3f5e7255aR1-R21) [[5]](diffhunk://#diff-5df62bfe8913245016e2308f3ca50b71022cb3b2670f8c6f0c8a470909207cfeL19-R28) [[6]](diffhunk://#diff-5df62bfe8913245016e2308f3ca50b71022cb3b2670f8c6f0c8a470909207cfeL185-R193) [[7]](diffhunk://#diff-5df62bfe8913245016e2308f3ca50b71022cb3b2670f8c6f0c8a470909207cfeL204-R230) [[8]](diffhunk://#diff-5df62bfe8913245016e2308f3ca50b71022cb3b2670f8c6f0c8a470909207cfeL236-R251) [[9]](diffhunk://#diff-bb5edd6d6fc874c25c68b583c824dce9c19d897318809cfd77dc95ab85899492L1-R16) [[10]](diffhunk://#diff-90b48e017a4207d3ee1c0143ee2a8cb655854755822d3b9683de6ccee4c008ccL46-L118) [[11]](diffhunk://#diff-90b48e017a4207d3ee1c0143ee2a8cb655854755822d3b9683de6ccee4c008ccL132-R96) [[12]](diffhunk://#diff-90b48e017a4207d3ee1c0143ee2a8cb655854755822d3b9683de6ccee4c008ccR166-R210) [[13]](diffhunk://#diff-90b48e017a4207d3ee1c0143ee2a8cb655854755822d3b9683de6ccee4c008ccL289-R227) [[14]](diffhunk://#diff-90b48e017a4207d3ee1c0143ee2a8cb655854755822d3b9683de6ccee4c008ccL312-R257) [[15]](diffhunk://#diff-84890fd9ef8ade0bab5506b06b7881dea0717d09d484f2ca28194a88164f8c43L36-R36)