### PR TITLE
fix: chart data needs to paginate date strings

### DIFF
--- a/ui/src/components/FlowChart.vue
+++ b/ui/src/components/FlowChart.vue
@@ -38,8 +38,8 @@ const rangeEndISO = computed<string | undefined>(() =>
 );
 
 const { incomes, expenses } = useFinancialData({
-  rangeStartRef: startRef,
-  rangeEndRef:   endRef,
+  rangeStartISO: rangeStartISO,
+  rangeEndISO:   rangeEndISO,
 });
 
 const chartData = computed(() => {


### PR DESCRIPTION
This pull request refactors the way date ranges are handled in the financial data components, switching from `Date` objects to ISO string representations for improved consistency and compatibility. It also updates the data fetching logic to robustly support paginated API responses and improves error handling.

**Date range handling improvements:**

* The `useFinancialData` composable now accepts `rangeStartISO` and `rangeEndISO` as computed ISO string references instead of `Date` objects, and the corresponding usage in `FlowChart.vue` has been updated to match. [[1]](diffhunk://#diff-38c2d381f765c39a9e1c1ffb99565c341fdbdf4b0139abf2836d2c34d9b0621cL41-R42) [[2]](diffhunk://#diff-5cd8bdfb3f98e81766630c868f1575e10bd39c681d504f854730747e0ad3702cR16-R22)

**Data fetching enhancements:**

* Introduced a `fetchAllPages` function to retrieve all pages of income and expense data, ensuring complete data is loaded even if paginated by the backend. The results are normalized using the new `normalizeList` utility.
* The main `fetchAll` function now utilizes `fetchAllPages` and builds query parameters only if start/end dates are present, improving flexibility and correctness.

**Error handling and type safety:**

* Improved error handling in the data fetching logic, including more robust checks for authentication errors and cleaner logging.
* Enhanced the `handleNewItem` function to more safely process incoming socket messages and avoid type errors.

**Lifecycle and reactivity updates:**

* Updated watchers and lifecycle hooks to use the new ISO string date references, ensuring data refreshes correctly when the date window changes.